### PR TITLE
Add local OpenAI provider for clearer custom setup, update docs

### DIFF
--- a/config-example/README.md
+++ b/config-example/README.md
@@ -1,6 +1,6 @@
 # Custom Configuration Example
 
-This directory shows how to use custom `llms.json` and `providers.json` configuration files with the Docker container.
+This directory shows how to use custom `llms.json` and `providers.json` configuration files with the Docker container. For full documentation, see [llmspy.org/docs/configuration](https://llmspy.org/docs/configuration).
 
 ## Quick Start
 
@@ -93,23 +93,22 @@ docker run -p 8000:8000 \
 
 ### Custom Provider Configuration
 
-Add a custom OpenAI-compatible provider:
+Add a custom OpenAI-compatible provider (LiteLLM, vLLM, text-generation-webui, etc.):
 
 ```json
 {
   "providers": {
-    "my-custom-provider": {
+    "my-backend": {
       "enabled": true,
-      "type": "OpenAiProvider",
-      "base_url": "https://api.example.com/v1",
-      "api_key": "$MY_CUSTOM_API_KEY",
-      "models": {
-        "my-model": "provider-model-name"
-      }
+      "npm": "openai-local",
+      "api": "http://localhost:8000/v1",
+      "api_key": "$MY_BACKEND_API_KEY"
     }
   }
 }
 ```
+
+The `openai-local` provider auto-discovers models via the `/models` endpoint. You can name the provider anything you want and use any environment variable for the API key. (Note: `npm` specifies the provider type, not an npm package.)
 
 ### Enable Only Free Providers
 

--- a/llms/llms.json
+++ b/llms/llms.json
@@ -247,6 +247,12 @@
             "api": "http://127.0.0.1:1234/v1",
             "models": {}
         },
+        "openai-local": {
+            "enabled": false,
+            "npm": "openai-local",
+            "api": "http://localhost:8000/v1",
+            "api_key": "$OPENAI_LOCAL_API_KEY"
+        },
         "google": {
             "enabled": true,
             "safety_settings": [

--- a/llms/main.py
+++ b/llms/main.py
@@ -1431,6 +1431,10 @@ class LMStudioProvider(OllamaProvider):
         return ret
 
 
+class OpenAiLocalProvider(LMStudioProvider):
+    sdk = "openai-local"
+
+
 def get_provider_model(model_name):
     for provider in g_handlers.values():
         provider_model = provider.provider_model(model_name)
@@ -2838,6 +2842,7 @@ class AppExtensions:
             CodestralProvider,
             OllamaProvider,
             LMStudioProvider,
+            OpenAiLocalProvider,
         ]
         self.aspect_ratios = {
             "1:1": "1024×1024",


### PR DESCRIPTION
## Summary

Adds an `openai-local` provider and fixes documentation to make setting up custom OpenAI-compatible endpoints clearer.

**Code changes:**

- Add `OpenAiLocalProvider` class (inherits from LMStudio) - a clearly-named provider for custom backends
- Add example entry in `llms.json`

**Documentation fixes:**

- Fix `config-example/README.md` that used incorrect field names (`type`/`base_url` → `npm`/`api`)
- Add explanation that `npm` specifies provider type, not an npm package
- Add link to main docs site

## Motivation

Setting up a custom OpenAI-compatible endpoint (LiteLLM, vLLM, text-generation-webui, etc.) was unclear:

- The `config-example/README.md` used incorrect syntax that wouldn't work
- One working approach (`npm: "lmstudio"`) was non-obvious and confusingly named for non-LMStudio backends, but since LMStudio currently provides 1-to-1 compatibility with OpenAI, it was used as the base

The new `openai-local` provider:

- Auto-discovers models via the `/models` endpoint (which inheriting `openai` and setting a custom endpoint does not allow for)
- Accepts any custom API key env var (as the logic already existed)
- Has a self-explanatory name for any OpenAI-compatible backend

## Example usage

```json
"my-openai-backend": {
  "enabled": true,
  "npm": "openai-local",
  "api": "http://localhost:8000/v1",
  "api_key": "$MY_BACKEND_API_KEY"
}
```

Note: The docs site at https://llmspy.org/docs/configuration may also want to document openai-local as an option.