### PR TITLE
Implement XDG Base Directory compliance

### DIFF
--- a/llms/xdg_migration.py
+++ b/llms/xdg_migration.py
@@ -1,0 +1,111 @@
+"""
+XDG Base Directory migration utilities.
+
+This module provides automatic migration from the legacy ~/.llms/ directory
+to XDG-compliant locations. This module can eventually be deprecated once
+all users have migrated.
+"""
+
+import os
+import shutil
+
+from .xdg_paths import get_cache_path, get_data_path, home_llms_path
+
+
+def migrate_to_xdg():
+    """
+    Migrate data from old ~/.llms/ to XDG-compliant directories.
+    This function is called on startup to ensure backward compatibility.
+    
+    Migration paths:
+    - Config: ~/.llms/ -> ~/.config/llms/
+    - Data: ~/.llms/user/ -> ~/.local/share/llms/user/
+    - Cache: ~/.llms/cache/ -> ~/.cache/llms/
+    """
+    # Don't migrate if LLMS_HOME is set (user wants custom location)
+    if os.getenv("LLMS_HOME"):
+        return
+    
+    old_home = os.path.join(os.path.expanduser("~"), ".llms")
+    
+    # Only migrate if old directory exists
+    if not os.path.exists(old_home):
+        return
+    
+    migrated_any = False
+    
+    # Migrate config files (llms.json, providers.json, extensions/)
+    new_config_dir = home_llms_path("")
+    config_files = ["llms.json", "providers.json"]
+    
+    for config_file in config_files:
+        old_file = os.path.join(old_home, config_file)
+        new_file = os.path.join(new_config_dir, config_file)
+        
+        if os.path.exists(old_file) and not os.path.exists(new_file):
+            try:
+                os.makedirs(new_config_dir, exist_ok=True)
+                shutil.copy2(old_file, new_file)
+                print(f"Migrated config: {old_file} -> {new_file}")
+                migrated_any = True
+            except Exception as e:
+                print(f"Warning: Failed to migrate {old_file}: {e}")
+    
+    # Migrate extensions directory
+    old_ext = os.path.join(old_home, "extensions")
+    new_ext = os.path.join(new_config_dir, "extensions")
+    
+    if os.path.exists(old_ext) and not os.path.exists(new_ext):
+        try:
+            os.makedirs(new_config_dir, exist_ok=True)
+            shutil.copytree(old_ext, new_ext)
+            print(f"Migrated extensions: {old_ext} -> {new_ext}")
+            migrated_any = True
+        except Exception as e:
+            print(f"Warning: Failed to migrate extensions: {e}")
+    
+    # Migrate user data
+    old_user = os.path.join(old_home, "user")
+    new_user = os.path.join(get_data_path(), "user")
+    
+    if os.path.exists(old_user) and not os.path.exists(new_user):
+        try:
+            os.makedirs(os.path.dirname(new_user), exist_ok=True)
+            shutil.copytree(old_user, new_user)
+            print(f"Migrated user data: {old_user} -> {new_user}")
+            migrated_any = True
+        except Exception as e:
+            print(f"Warning: Failed to migrate user data: {e}")
+    
+    # Migrate cache
+    old_cache = os.path.join(old_home, "cache")
+    new_cache = get_cache_path()
+    
+    if os.path.exists(old_cache) and not os.path.exists(new_cache):
+        try:
+            os.makedirs(os.path.dirname(new_cache), exist_ok=True)
+            shutil.copytree(old_cache, new_cache)
+            print(f"Migrated cache: {old_cache} -> {new_cache}")
+            migrated_any = True
+        except Exception as e:
+            print(f"Warning: Failed to migrate cache: {e}")
+    
+    if migrated_any:
+        print(f"Migration complete. Old directory still exists at {old_home}")
+        print(f"You can remove it manually: rm -rf {old_home}")
+        
+        # Create a warning file in the old directory with a very clear name
+        warning_file = os.path.join(old_home, "README__THIS_DIRECTORY_IS_OBSOLETE")
+        try:
+            with open(warning_file, "w") as f:
+                f.write("This directory is obsolete and has been migrated to XDG-compliant locations.\n\n")
+                f.write("New locations:\n")
+                f.write(f"  - Config:     {home_llms_path('')}\n")
+                f.write(f"  - User data:  {get_data_path('')}\n")
+                f.write(f"  - Cache:      {get_cache_path('')}\n\n")
+                f.write("This directory can be safely deleted:\n")
+                f.write(f"  rm -rf {old_home}\n\n")
+                f.write("For more information, see: https://specifications.freedesktop.org/basedir-spec/\n")
+        except Exception as e:
+            print(f"Warning: Failed to create migration notice file: {e}")
+

--- a/llms/xdg_paths.py
+++ b/llms/xdg_paths.py
@@ -1,0 +1,104 @@
+"""
+XDG Base Directory path resolution utilities.
+
+This module provides functions for XDG-compliant path resolution,
+implementing the XDG Base Directory Specification.
+"""
+
+import os
+
+
+def get_xdg_config_home():
+    """Get XDG_CONFIG_HOME directory, defaulting to ~/.config"""
+    xdg_config = os.getenv("XDG_CONFIG_HOME")
+    if xdg_config:
+        return xdg_config
+    return os.path.join(os.path.expanduser("~"), ".config")
+
+
+def get_xdg_data_home():
+    """Get XDG_DATA_HOME directory, defaulting to ~/.local/share"""
+    xdg_data = os.getenv("XDG_DATA_HOME")
+    if xdg_data:
+        return xdg_data
+    return os.path.join(os.path.expanduser("~"), ".local", "share")
+
+
+def get_xdg_cache_home():
+    """Get XDG_CACHE_HOME directory, defaulting to ~/.cache"""
+    xdg_cache = os.getenv("XDG_CACHE_HOME")
+    if xdg_cache:
+        return xdg_cache
+    return os.path.join(os.path.expanduser("~"), ".cache")
+
+
+def home_llms_path(filename):
+    """
+    Get path for config files using XDG Base Directory specification.
+    Priority: LLMS_HOME > LLMS_CONFIG_HOME > XDG_CONFIG_HOME > ~/.config/llms
+    
+    For backward compatibility, LLMS_HOME overrides all XDG paths.
+    """
+    # LLMS_HOME is legacy and overrides everything
+    if os.getenv("LLMS_HOME"):
+        home_dir = os.getenv("LLMS_HOME")
+    # LLMS_CONFIG_HOME for explicit config override
+    elif os.getenv("LLMS_CONFIG_HOME"):
+        home_dir = os.getenv("LLMS_CONFIG_HOME")
+    # XDG_CONFIG_HOME for XDG-compliant config
+    else:
+        home_dir = os.path.join(get_xdg_config_home(), "llms")
+    
+    relative_path = os.path.join(home_dir, filename)
+    # return resolved full absolute path
+    return os.path.abspath(os.path.normpath(relative_path))
+
+
+def get_data_path(relative_path=""):
+    """
+    Get path for user data using XDG Base Directory specification.
+    Priority: LLMS_HOME > LLMS_DATA_HOME > XDG_DATA_HOME > ~/.local/share/llms
+    
+    For backward compatibility, LLMS_HOME overrides all XDG paths.
+    """
+    # LLMS_HOME is legacy and overrides everything (backward compatibility)
+    if os.getenv("LLMS_HOME"):
+        data_dir = os.getenv("LLMS_HOME")
+    # LLMS_DATA_HOME for explicit data override
+    elif os.getenv("LLMS_DATA_HOME"):
+        data_dir = os.getenv("LLMS_DATA_HOME")
+    # XDG_DATA_HOME for XDG-compliant data
+    else:
+        data_dir = os.path.join(get_xdg_data_home(), "llms")
+    
+    if relative_path:
+        full_path = os.path.join(data_dir, relative_path)
+    else:
+        full_path = data_dir
+    
+    return os.path.abspath(os.path.normpath(full_path))
+
+
+def get_cache_path(path=""):
+    """
+    Get path for cache using XDG Base Directory specification.
+    Priority: LLMS_HOME > LLMS_CACHE_HOME > XDG_CACHE_HOME > ~/.cache/llms
+    
+    For backward compatibility, LLMS_HOME overrides all XDG paths.
+    """
+    # LLMS_HOME is legacy and overrides everything (backward compatibility)
+    if os.getenv("LLMS_HOME"):
+        cache_dir = os.path.join(os.getenv("LLMS_HOME"), "cache")
+    # LLMS_CACHE_HOME for explicit cache override
+    elif os.getenv("LLMS_CACHE_HOME"):
+        cache_dir = os.getenv("LLMS_CACHE_HOME")
+    # XDG_CACHE_HOME for XDG-compliant cache
+    else:
+        cache_dir = os.path.join(get_xdg_cache_home(), "llms")
+    
+    if path:
+        full_path = os.path.join(cache_dir, path)
+    else:
+        full_path = cache_dir
+    
+    return os.path.abspath(os.path.normpath(full_path))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -22,12 +22,14 @@ class TestHomeLlmsPath(unittest.TestCase):
     def test_home_llms_path(self):
         result = home_llms_path("llms.json")
         self.assertIsInstance(result, str)
-        self.assertTrue(result.endswith("/.llms/llms.json"))
+        # Now uses XDG config directory by default
+        self.assertTrue(result.endswith("/.config/llms/llms.json") or result.endswith("/llms.json"))
 
     def test_home_llms_path_providers(self):
         result = home_llms_path("providers.json")
         self.assertIsInstance(result, str)
-        self.assertTrue(result.endswith("/.llms/providers.json"))
+        # Now uses XDG config directory by default
+        self.assertTrue(result.endswith("/.config/llms/providers.json") or result.endswith("/providers.json"))
 
 
 class TestProviderStatus(unittest.TestCase):

--- a/tests/test_xdg_paths.py
+++ b/tests/test_xdg_paths.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""
+Unit tests for XDG Base Directory path resolution in llms.main module.
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+# Add parent directory to path to import llms module
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from llms.main import (
+    home_llms_path,
+    get_data_path,
+    get_cache_path,
+    get_xdg_config_home,
+    get_xdg_data_home,
+    get_xdg_cache_home,
+)
+
+
+class TestXDGHelpers(unittest.TestCase):
+    """Test XDG helper functions."""
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_get_xdg_config_home_no_home(self):
+        """Test XDG_CONFIG_HOME works even without HOME env var"""
+        result = get_xdg_config_home()
+        # Should use os.path.expanduser("~") which works without HOME
+        self.assertTrue(result.endswith("/.config"))
+
+    @patch.dict(os.environ, {"HOME": "/home/testuser"}, clear=True)
+    def test_get_xdg_config_home_default(self):
+        """Test XDG_CONFIG_HOME defaults to ~/.config"""
+        result = get_xdg_config_home()
+        self.assertEqual(result, "/home/testuser/.config")
+
+    @patch.dict(os.environ, {"HOME": "/home/testuser", "XDG_CONFIG_HOME": "/custom/config"}, clear=True)
+    def test_get_xdg_config_home_custom(self):
+        """Test XDG_CONFIG_HOME respects environment variable"""
+        result = get_xdg_config_home()
+        self.assertEqual(result, "/custom/config")
+
+    @patch.dict(os.environ, {"HOME": "/home/testuser"}, clear=True)
+    def test_get_xdg_data_home_default(self):
+        """Test XDG_DATA_HOME defaults to ~/.local/share"""
+        result = get_xdg_data_home()
+        self.assertEqual(result, "/home/testuser/.local/share")
+
+    @patch.dict(os.environ, {"HOME": "/home/testuser", "XDG_DATA_HOME": "/custom/data"}, clear=True)
+    def test_get_xdg_data_home_custom(self):
+        """Test XDG_DATA_HOME respects environment variable"""
+        result = get_xdg_data_home()
+        self.assertEqual(result, "/custom/data")
+
+    @patch.dict(os.environ, {"HOME": "/home/testuser"}, clear=True)
+    def test_get_xdg_cache_home_default(self):
+        """Test XDG_CACHE_HOME defaults to ~/.cache"""
+        result = get_xdg_cache_home()
+        self.assertEqual(result, "/home/testuser/.cache")
+
+    @patch.dict(os.environ, {"HOME": "/home/testuser", "XDG_CACHE_HOME": "/custom/cache"}, clear=True)
+    def test_get_xdg_cache_home_custom(self):
+        """Test XDG_CACHE_HOME respects environment variable"""
+        result = get_xdg_cache_home()
+        self.assertEqual(result, "/custom/cache")
+
+
+class TestHomeLlmsPathXDG(unittest.TestCase):
+    """Test home_llms_path with XDG compliance."""
+
+    @patch.dict(os.environ, {"HOME": "/home/testuser"}, clear=True)
+    def test_home_llms_path_xdg_default(self):
+        """Test home_llms_path uses XDG config directory by default"""
+        result = home_llms_path("llms.json")
+        self.assertEqual(result, "/home/testuser/.config/llms/llms.json")
+
+    @patch.dict(os.environ, {"HOME": "/home/testuser", "XDG_CONFIG_HOME": "/custom/config"}, clear=True)
+    def test_home_llms_path_xdg_custom(self):
+        """Test home_llms_path respects XDG_CONFIG_HOME"""
+        result = home_llms_path("llms.json")
+        self.assertEqual(result, "/custom/config/llms/llms.json")
+
+    @patch.dict(os.environ, {"HOME": "/home/testuser", "LLMS_CONFIG_HOME": "/llms/config"}, clear=True)
+    def test_home_llms_path_llms_config_home(self):
+        """Test home_llms_path respects LLMS_CONFIG_HOME"""
+        result = home_llms_path("llms.json")
+        self.assertEqual(result, "/llms/config/llms.json")
+
+    @patch.dict(os.environ, {"HOME": "/home/testuser", "LLMS_HOME": "/legacy/llms"}, clear=True)
+    def test_home_llms_path_legacy_llms_home(self):
+        """Test home_llms_path respects LLMS_HOME for backward compatibility"""
+        result = home_llms_path("llms.json")
+        self.assertEqual(result, "/legacy/llms/llms.json")
+
+    @patch.dict(
+        os.environ,
+        {
+            "HOME": "/home/testuser",
+            "LLMS_HOME": "/legacy/llms",
+            "LLMS_CONFIG_HOME": "/llms/config",
+            "XDG_CONFIG_HOME": "/custom/config",
+        },
+        clear=True,
+    )
+    def test_home_llms_path_priority(self):
+        """Test LLMS_HOME takes priority over all other settings"""
+        result = home_llms_path("llms.json")
+        self.assertEqual(result, "/legacy/llms/llms.json")
+
+
+class TestGetDataPath(unittest.TestCase):
+    """Test get_data_path for user data."""
+
+    @patch.dict(os.environ, {"HOME": "/home/testuser"}, clear=True)
+    def test_get_data_path_default(self):
+        """Test get_data_path uses XDG data directory by default"""
+        result = get_data_path("user/default")
+        self.assertEqual(result, "/home/testuser/.local/share/llms/user/default")
+
+    @patch.dict(os.environ, {"HOME": "/home/testuser", "XDG_DATA_HOME": "/custom/data"}, clear=True)
+    def test_get_data_path_xdg_custom(self):
+        """Test get_data_path respects XDG_DATA_HOME"""
+        result = get_data_path("user/default")
+        self.assertEqual(result, "/custom/data/llms/user/default")
+
+    @patch.dict(os.environ, {"HOME": "/home/testuser", "LLMS_DATA_HOME": "/llms/data"}, clear=True)
+    def test_get_data_path_llms_data_home(self):
+        """Test get_data_path respects LLMS_DATA_HOME"""
+        result = get_data_path("user/default")
+        self.assertEqual(result, "/llms/data/user/default")
+
+    @patch.dict(os.environ, {"HOME": "/home/testuser", "LLMS_HOME": "/legacy/llms"}, clear=True)
+    def test_get_data_path_legacy_llms_home(self):
+        """Test get_data_path respects LLMS_HOME for backward compatibility"""
+        result = get_data_path("user/default")
+        self.assertEqual(result, "/legacy/llms/user/default")
+
+    @patch.dict(os.environ, {"HOME": "/home/testuser"}, clear=True)
+    def test_get_data_path_no_relative(self):
+        """Test get_data_path returns base directory when no relative path"""
+        result = get_data_path()
+        self.assertEqual(result, "/home/testuser/.local/share/llms")
+
+
+class TestGetCachePath(unittest.TestCase):
+    """Test get_cache_path for cache files."""
+
+    @patch.dict(os.environ, {"HOME": "/home/testuser"}, clear=True)
+    def test_get_cache_path_default(self):
+        """Test get_cache_path uses XDG cache directory by default"""
+        result = get_cache_path("media")
+        self.assertEqual(result, "/home/testuser/.cache/llms/media")
+
+    @patch.dict(os.environ, {"HOME": "/home/testuser", "XDG_CACHE_HOME": "/custom/cache"}, clear=True)
+    def test_get_cache_path_xdg_custom(self):
+        """Test get_cache_path respects XDG_CACHE_HOME"""
+        result = get_cache_path("media")
+        self.assertEqual(result, "/custom/cache/llms/media")
+
+    @patch.dict(os.environ, {"HOME": "/home/testuser", "LLMS_CACHE_HOME": "/llms/cache"}, clear=True)
+    def test_get_cache_path_llms_cache_home(self):
+        """Test get_cache_path respects LLMS_CACHE_HOME"""
+        result = get_cache_path("media")
+        self.assertEqual(result, "/llms/cache/media")
+
+    @patch.dict(os.environ, {"HOME": "/home/testuser", "LLMS_HOME": "/legacy/llms"}, clear=True)
+    def test_get_cache_path_legacy_llms_home(self):
+        """Test get_cache_path respects LLMS_HOME for backward compatibility"""
+        result = get_cache_path("media")
+        self.assertEqual(result, "/legacy/llms/cache/media")
+
+    @patch.dict(os.environ, {"HOME": "/home/testuser"}, clear=True)
+    def test_get_cache_path_no_relative(self):
+        """Test get_cache_path returns base directory when no relative path"""
+        result = get_cache_path()
+        self.assertEqual(result, "/home/testuser/.cache/llms")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adopt XDG Base Directory convention for config, data, and cache instead of using  `~/.llms`. This centralizes files in standard locations (XDG_CONFIG_HOME, XDG_DATA_HOME, XDG_CACHE_HOME), improving discoverability, backups, cross-platform compatibility, and system integration while allowing a safe migration from the legacy `~/.llms`.